### PR TITLE
Blind fix for production bug 

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,7 +1,7 @@
 (function() {
   async function getJSONData() {
     try {
-      let response = await fetch("/assets/js/projects.json/");
+      let response = await fetch("/assets/js/projects.json");
       let data = await response.json();
       return data;
     } catch(error) {


### PR DESCRIPTION
I'm not sure why this wasn't causing a problem locally, but I think dropping the trailing slash could be the fix 🤞 

If that doesn't work, I have another idea. But let's see if this fixes it first. Since I couldn't reproduce the bug locally, I think you have to merge this and then we can check if it worked in production. 

## ⚠️ Adding clarifying context post-merge
I realized while explaining this in slack that it will be helpful here. This is only step one in a complete fix. This should fix the 404 error for `projects.json`.  
<img width="500" alt="Screenshot 2023-07-25 at 12 14 43 PM" src="https://github.com/norawarschewski/tw-2023/assets/10406456/94dda0f0-fda7-46dd-aad1-72a3ec728aad">

Since I can't recreate the problem locally, I wanted to see if this works before moving on to fixing the grid not populating.

What I wrote in slack:

> If it doesn't work, i have an idea of what the new problem is. But with this PR I at least want to get rid of the 404 error that says projects.json can't be found. Since i can't recreate what's happening locally, it makes the bug a bit slower to fix.
>
> In production the url includes  2023/revivals or 2023/revivals/revival/  and under the hood it's going to the respective index.html , which runs the javascript as expected. But then can't find projects.json (presumably because of the trailing slash).  So we can get to the pages but the grid doesn't populate.
>
> Locally, the home page and the project page don't include those bits in the url.  So some of the logic in the code probably won't work still, even after getting the data from projects.json .
>
> But fixing it should be simple (famous last words) . I have to change the logic around looking for the word 'revivals' in the path because that made sense locally but not with the URL in production. See these line:
https://github.com/norawarschewski/tw-2023/blob/49447f5e20e5824c079d86c837831918bd676d98/assets/js/scripts.js#L30-L36 (edited) 