### PR TITLE
Prod fix take 2

### DIFF
--- a/assets/js/projects.json
+++ b/assets/js/projects.json
@@ -2,115 +2,115 @@
   {
     "title": "Reece",
     "designer": "Nora Warschewski",
-    "url": "../reece/",
+    "url": "/reece/",
     "img": "/reece/thumbnail.jpg"
   },
   {
     "title": "Gautina",
     "designer": "Joke de Winter",
-    "url": "../gautina/",
+    "url": "/gautina/",
     "img": "/gautina/thumbnail.jpg"
   },
   {
     "title": "Reincarnation",
     "designer": "Quang Huy Lê",
-    "url": "../reincarnation/",
+    "url": "/reincarnation/",
     "img": "/reincarnation/thumbnail.jpg"
   },
   {
     "title": "Eusebius",
     "designer": "David Huang",
-    "url": "../eusebius/",
+    "url": "/eusebius/",
     "img": "/eusebius/thumbnail.jpg"
   },
   {
     "title": "Charlotte",
     "designer": "Adriana Garcidueñas",
-    "url": "../charlotte/",
-    "img": "charlotte/thumbnail.jpeg"
+    "url": "/charlotte/",
+    "img": "/charlotte/thumbnail.jpeg"
   },
   {
     "title": "Xerxes",
     "designer": "Beto López Tristán",
-    "url": "../xerxes/",
-    "img": "xerxes/thumbnail.jpg"
+    "url": "/xerxes/",
+    "img": "/xerxes/thumbnail.jpg"
   },
   {
     "title": "Sojourn",
     "designer": "Avery Lee Qiu Wen",
-    "url": "../sojourn/",
-    "img": "sojourn/thumbnail.png"
+    "url": "/sojourn/",
+    "img": "/sojourn/thumbnail.png"
   },
   {
     "title": "Jean",
     "designer": "Caroline Rodrigues de Lima",
-    "url": "../jean/",
-    "img": "jean/thumbnail.jpg"
+    "url": "/jean/",
+    "img": "/jean/thumbnail.jpg"
   },
   {
     "title": "Willo",
     "designer": "Jacob Witt",
-    "url": "../willo/",
-    "img": "willo/thumbnail.jpg"
+    "url": "/willo/",
+    "img": "/willo/thumbnail.jpg"
   },
   {
     "title": "Jakob",
     "designer": "Rishi Murugesan ",
-    "url": "../jakob/",
-    "img": "jakob/thumbnail.jpg"
+    "url": "/jakob/",
+    "img": "/jakob/thumbnail.jpg"
   },
   {
     "title": "Agitate",
     "designer": "Kurt F. Shaffert",
-    "url": "../agitate/",
-    "img": "agitate/thumbnail.jpg"
+    "url": "/agitate/",
+    "img": "/agitate/thumbnail.jpg"
   },
   {
     "title": "Hasten",
     "designer": "Julia Liang",
-    "url": "../hasten/",
-    "img": "hasten/thumbnail.jpg"
+    "url": "/hasten/",
+    "img": "/hasten/thumbnail.jpg"
   },
   {
     "title": "Mechanik",
     "designer": "Raquel Rodriguez",
-    "url": "../mechanick/",
-    "img": "mechanick/thumbnail.png"
+    "url": "/mechanick/",
+    "img": "/mechanick/thumbnail.png"
   },
   {
     "title": "Figgy V.",
     "designer": "Allie Schmitz",
-    "url": "../figgy-v/",
-    "img": "figgy-v/thumbnail.jpg"
+    "url": "/figgy-v/",
+    "img": "/figgy-v/thumbnail.jpg"
   },
   {
     "title": "Julieta",
     "designer": "Alejandra Hernandez Chavez",
-    "url": "../julieta/",
-    "img": "julieta/thumbnail.png"
+    "url": "/julieta/",
+    "img": "/julieta/thumbnail.png"
   },
   {
     "title": "Wicked",
     "designer": "Aasawari S. Kulkarni",
-    "url": "../wicked/",
-    "img": "wicked/thumbnail.jpg"
+    "url": "/wicked/",
+    "img": "/wicked/thumbnail.jpg"
   },
   {
     "title": "BK Ferry",
     "designer": "Tim Cronin",
-    "url": "../bk-ferry/",
-    "img": "bkferry/thumbnail.png"
+    "url": "/bk-ferry/",
+    "img": "/bkferry/thumbnail.png"
   },
   {
     "title": "Paige",
     "designer": "Sarah Wong",
-    "url": "../paige/",
-    "img": "paige/thumbnail.png"
+    "url": "/paige/",
+    "img": "/paige/thumbnail.png"
   },
   {
     "title": "Ronda",
     "designer": "Rong Xiang",
-    "url": "../ronda/",
-    "img": "ronda/thumbnail.jpg"
+    "url": "/ronda/",
+    "img": "/ronda/thumbnail.jpg"
   }
 ]

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,7 +1,11 @@
 (function() {
+   // Set the path and onHomepage variables to help determine the correct path for fetching JSON data, render the correct img.src and href values in the HTML, and to pass on to shuffleArray fn.
+  let path = window.location.pathname;
+  let onHomepage = path == '/2023/revivals/' || path =='/2023/revivals/index.html';
+
   async function getJSONData() {
     try {
-      let response = await fetch("./assets/js/projects.json");
+      let response = await fetch(onHomepage ? "./assets/js/projects.json" : "./../assets/js/projects.json");
       let data = await response.json();
       return data;
     } catch(error) {
@@ -12,12 +16,12 @@
   /*
   The project grid data is shuffled on both the index and project pages. When a user is on a project page we remove the current project from the grid using the filterArray fn and then shuffle.
   */
-  function shuffleArray(fontData, onProjectPage, path) {
+  function shuffleArray(fontData, onHomepage, path) {
     function filterArray() {
       return fontData.filter((el) => !el.url.includes(path));
     }
 
-    let array = (!onProjectPage) ? fontData : filterArray();
+    let array = (onHomepage) ? fontData : filterArray();
 
     for (let i = array.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -27,13 +31,9 @@
   }
 
   async function projectGridSetup() {
-    // Set the path and onProjectPage variables to help render the correct img.src and href values in the HTML, and to pass on to shuffleArray fn.
-    let path = window.location.pathname;
-    let onProjectPage = path.includes('revivals'); // ie, revival/reece/
-
     // Get data
     let fontData = await getJSONData();
-    let shuffledData = shuffleArray(fontData, onProjectPage, path);
+    let shuffledData = shuffleArray(fontData, onHomepage, path);
 
     // Render the project grid
     const parent = document.getElementById("projectGrid");
@@ -41,11 +41,11 @@
       const project = shuffledData[i];
 
       const singleProject = document.createElement("a");
-      singleProject.href = !onProjectPage ? project.url : `./${project.url}`;
+      singleProject.href = onHomepage ? `.${project.url}` : `./..${project.url}`;
       singleProject.setAttribute("id", i);
 
       const img = document.createElement("img");
-      img.src = !onProjectPage ? `./assets/img/${project.img}` : `./assets/img/${project.img}`;
+      img.src = onHomepage ? `./assets/img${project.img}` : `./../assets/img${project.img}`;
 
       const description = document.createElement("div");
       description.innerHTML += `


### PR DESCRIPTION
## Problem
Production is not working properly. I've broken down into 2 distinct problems.
Again, these were not present in the local environment or netlify app so trickier to troubleshoot.

### Problem 1
The homepage loads with the project grid. Yay! But..
- The href links from the grid on the homepage lead to 404s 😢 
   <img width="500" alt="Screenshot_2023-07-27_at_11_05_25_AM" src="https://github.com/norawarschewski/tw-2023/assets/10406456/c7c80cf8-f621-4d82-9f23-fd359023d0c6">

- So you end up here: 
   <img width="500" alt="Screenshot_2023-07-27_at_11_05_36_AM" src="https://github.com/norawarschewski/tw-2023/assets/10406456/87379e84-8335-443f-ba58-db25eb8e8b1a">

- Manually changing the `href` attribute in the browser shows it's a problem with path. When I navigate using the new path, it works as expected.
   See the correct path:
   <img width="500" alt="Screenshot_2023-07-27_at_11_25_35_AM" src="https://github.com/norawarschewski/tw-2023/assets/10406456/ad8640cc-6c73-4a8d-a855-acb239a96fdb">

### Problem 2
When I manually navigate to a project page (ie, https://typewest.letterformarchive.org/2023/revivals/ronda/), it loads but...
- the grid does not populate 😢 
   <img width="500" alt="Screenshot_2023-07-27_at_10_52_30_AM" src="https://github.com/norawarschewski/tw-2023/assets/10406456/c76080b0-4814-4af2-84ed-a9b5a7697b9d">

- Manually running the fetch request in the production browser shows that it's a problem with the path to the resource.
   <img width="500" alt="Screenshot_2023-07-27_at_10_59_32_AM" src="https://github.com/norawarschewski/tw-2023/assets/10406456/48e6f7b7-8006-4cd3-a8f9-363d220e73c8">

This means that the path that worked in the fetch request on the homepage does not work on the project page.


## Solution
As mentioned above, we need to account for different paths from the homepage and the project page.

To start with, I get the `window.location.pathname` to determine if the user is on the homepage or not and then adjust the paths as needed. This is done for the request paths in the `fetch()` method itself and also for rendering the grid `href` and `img.src` on the pages. 

We know that the `img.src` works already in production so I leveraged that to help figure out the correct paths for the other paths in the rendered grid. And running the `fetch()` request in the browser console helped figure out the fetch paths.

Screenshots from a browser running the local environment don't help explain much so nothing to show. But I explain a bit more in the files.


